### PR TITLE
Updated to support Magento EE FPC

### DIFF
--- a/Cm/Cache/Backend/Mongo.php
+++ b/Cm/Cache/Backend/Mongo.php
@@ -332,7 +332,11 @@ class Cm_Cache_Backend_Mongo extends Zend_Cache_Backend implements Zend_Cache_Ba
     {
         try {
         	
-        	array_walk_recursive($data, array($this, 'checkUtf8OnSave'));
+        	if (is_array($data)) {
+	        	array_walk_recursive($data, array($this, 'checkUtf8OnSave'));
+        	} else {
+        		$this->checkUtf8OnSave($data);
+        	}
         	
             $result = $this->_collection->update(array('_id' => $id), $data, $options);
             if ($result === TRUE || $result['ok']) {

--- a/Cm/Cache/Backend/Mongo.php
+++ b/Cm/Cache/Backend/Mongo.php
@@ -39,8 +39,7 @@ class Cm_Cache_Backend_Mongo extends Zend_Cache_Backend implements Zend_Cache_Ba
         'server'     => self::DEFAULT_SERVER, // See http://us1.php.net/manual/en/mongoclient.construct.php
         'dbname'     => self::DEFAULT_DBNAME,
         'collection' => self::DEFAULT_COLLECTION,
-        'ensure_index' => TRUE,
-    	'check_utf8'	=> FALSE
+        'ensure_index' => TRUE
     );
 
     /**


### PR DESCRIPTION
If you are going to use this with the Magento EE Full Page Cache the binary data that results, caused by automatic gzipping, causes Mongo to reject the insertion, thus removing most of, if not all of, the benefit of using the FPC.  This change automatically converts non-UTF8-based content to a MongoBinData object on save and back to a string on load.  It does this by doing a preg_match('!!u') to see if it contains non-UTF8 data.  If so it will convert the string to MongoBinData.  When content is loaded it will check the data type of the requested object and return the binary representation.
